### PR TITLE
修复replaceNamesAndAliasIn()方法无法替换'AS'的bug

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1339,7 +1339,7 @@ class Connection
     {
         $quoted = $this->replaceNamesIn($val);
         $pos    = strripos($quoted, ' AS ');
-        if ($pos) {
+        if ($pos !== false) {
             $alias  = $this->replaceName(substr($quoted, $pos + 4));
             $quoted = substr($quoted, 0, $pos) . " AS $alias";
         }


### PR DESCRIPTION
strripos查询成功如果返回位置为0，无法进入下面的if判断，
所以应该将if的判断改为 $pos !== false