### PR TITLE
问题：插入表数据时，若字段值为 null，但数据库实际插入的值却为空字符串。

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1740,8 +1740,7 @@ class Connection
             $this->bindMore($parameters);
             if (!empty($this->parameters)) {
                 foreach ($this->parameters as $param) {
-                    $parameters = explode("\x7F", $param);
-                    $this->sQuery->bindParam($parameters[0], $parameters[1]);
+                    $this->sQuery->bindParam($param[0], $param[1]);
                 }
             }
             $this->success = $this->sQuery->execute();
@@ -1756,8 +1755,7 @@ class Connection
                     $this->bindMore($parameters);
                     if (!empty($this->parameters)) {
                         foreach ($this->parameters as $param) {
-                            $parameters = explode("\x7F", $param);
-                            $this->sQuery->bindParam($parameters[0], $parameters[1]);
+                            $this->sQuery->bindParam($param[0], $param[1]);
                         }
                     }
                     $this->success = $this->sQuery->execute();
@@ -1785,9 +1783,9 @@ class Connection
     public function bind($para, $value)
     {
         if (is_string($para)) {
-            $this->parameters[sizeof($this->parameters)] = ":" . $para . "\x7F" . $value;
+            $this->parameters[sizeof($this->parameters)] = array(":" . $para, $value);
         } else {
-            $this->parameters[sizeof($this->parameters)] = $para . "\x7F" . $value;
+            $this->parameters[sizeof($this->parameters)] = array($para, $value);
         }
     }
 


### PR DESCRIPTION
原因：在 $this->bind() 函数里，键值进行字符串拼接导致 null 转化为空字符串。
方案：不要对键值进行字符串拼接，改为使用数组处理即可。