### PR TITLE
cancel force order suffix

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -107,7 +107,7 @@ class Connection
      *
      * @var bool
      */
-    protected $order_asc = true;
+    protected $order_asc = null;
     /**
      * SELECT 多少记录
      *
@@ -1212,12 +1212,15 @@ class Connection
         if (!$this->order_by) {
             return '';
         }
-
-        if ($this->order_asc) {
-            return ' ORDER BY' . $this->indentCsv($this->order_by) . ' ASC';
+        
+        $r = ' ORDER BY' . $this->indentCsv($this->order_by);
+        if(isset($this->order_asc)) {
+            $r .= ($this->order_asc)? ' ASC' : ' DESC';
         } else {
-            return ' ORDER BY' . $this->indentCsv($this->order_by) . ' DESC';
+            // depend on devloper if $this->order_asc is not set.
+            // devloper can call function orderBy() to set $this->order_by.
         }
+        return $r;
     }
 
     /**


### PR DESCRIPTION
we can use both ASC and DESC in a sql.

example:
    Connection->select('ID, Name')
                            ->from('MyTable')
                            ->orderBy(array('ID ASC', 'Name DESC'))
                            ->row();