### PR TITLE
fix bug: reset $this->order_asc

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1020,6 +1020,7 @@ class Connection
      */
     public function orderBy(array $cols)
     {
+        $this->order_asc = null;
         return $this->addOrderBy($cols);
     }
 


### PR DESCRIPTION
The sql will get error with duplicate ASC when execute orderBy() after orderByASC()/orderByDESC().