### PR TITLE
fix: 当 $this->db 不为 null 时，才调用 rollBackTrans

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1768,7 +1768,9 @@ class Connection
                     throw $ex;
                 }
             } else {
-                $this->rollBackTrans();
+                if ($this->db) {
+                     $this->rollBackTrans();
+                }
                 $msg = $e->getMessage();
                 $err_msg = "SQL:".$this->lastSQL()." ".$msg;
                 $exception = new \PDOException($err_msg, (int)$e->getCode());


### PR DESCRIPTION
假如 PDOException->errorInfo[1] 不等于 2006 或 2013 时，需要判断 $this->db 是否为空。